### PR TITLE
Make /usr/local/cargo writable for non-root PTY users

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -60,7 +60,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
        | sh -s -- -y --default-toolchain stable --profile minimal \
          --component clippy --component rustfmt \
-  && chmod -R a+rX /usr/local/rustup /usr/local/cargo
+  # a+rwX so non-root PTY users can populate the registry / target
+  # caches under /usr/local/cargo. The installer writes everything
+  # root-owned; matching the official rust image's "shared toolchain"
+  # convention. Without this, `make ci` inside a dev PTY fails on
+  # the first crate fetch with "Permission denied".
+  && chmod -R a+rwX /usr/local/rustup /usr/local/cargo
 
 # GitHub CLI from the official apt source — not in Debian's main repos.
 RUN mkdir -p -m 755 /etc/apt/keyrings \

--- a/frontend/src/components/TimelinePane.tsx
+++ b/frontend/src/components/TimelinePane.tsx
@@ -20,6 +20,7 @@ import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { getRepoTimeline, getTimeline } from "../api/client";
 import type { TimelineQuery, TimelineResponse, TimelineSubagent } from "../api/types";
 import { useMediaQuery } from "../hooks/useMediaQuery";
+import { useTabs } from "../state/TabStore";
 import { FilterChips } from "./timeline/FilterChips";
 import { useTimelineFilters } from "./timeline/filters";
 import { type ToolPair, type Turn } from "./timeline/grouping";
@@ -36,12 +37,14 @@ const MIN_INSPECTOR_FRACTION = 0.28;
 const MAX_INSPECTOR_FRACTION = 0.78;
 
 export function TimelinePane({
+  tabId,
   sessionId,
   repo,
   focusTurnId,
   focusPairId,
   focusKey,
 }: {
+  tabId?: string;
   sessionId?: string;
   repo?: string;
   focusTurnId?: number;
@@ -178,6 +181,19 @@ export function TimelinePane({
   }, []);
   const closeSubagent = useCallback(() => setSubagent(null), []);
 
+  // A manual click in the turn list is the user overriding whatever
+  // focus the tab was opened with. Strip the focus fields from the
+  // tab so later polls (or tab revisits) don't re-apply them — and
+  // so the persistent focus outline on a tool row goes away.
+  const clearTimelineFocus = useTabs((store) => store.clearTimelineFocus);
+  const handleTurnSelect = useCallback(
+    (key: string) => {
+      setSelectedTurnKey(key);
+      if (tabId) clearTimelineFocus(tabId);
+    },
+    [tabId, clearTimelineFocus],
+  );
+
   const onDividerMouseDown = useCallback(
     (e: ReactMouseEvent<HTMLDivElement>) => {
       e.preventDefault();
@@ -264,7 +280,7 @@ export function TimelinePane({
               turns={turns}
               selectedTurnKey={selectedTurnKey}
               showThinking={filters.showThinking}
-              onSelect={setSelectedTurnKey}
+              onSelect={handleTurnSelect}
               virtuosoRef={virtuoso}
             />
           </div>
@@ -289,7 +305,7 @@ export function TimelinePane({
               turns={turns}
               selectedTurnKey={selectedTurnKey}
               showThinking={filters.showThinking}
-              onSelect={setSelectedTurnKey}
+              onSelect={handleTurnSelect}
               virtuosoRef={virtuoso}
             />
           </div>

--- a/frontend/src/components/WorkArea.tsx
+++ b/frontend/src/components/WorkArea.tsx
@@ -636,6 +636,7 @@ function TabContent({ tab }: { tab: TabData }) {
       case "timeline":
         return (
           <TimelinePane
+            tabId={tab.id}
             sessionId={tab.sessionId}
             repo={tab.repo}
             focusTurnId={tab.focusTurnId}

--- a/frontend/src/state/TabStore.test.ts
+++ b/frontend/src/state/TabStore.test.ts
@@ -75,3 +75,51 @@ describe("TabStore pair-linked activation", () => {
     expect(useTabStore.getState().activeByPane.bottom).toBe(timeA);
   });
 });
+
+describe("TabStore clearTimelineFocus", () => {
+  beforeEach(() => {
+    resetTabStore();
+  });
+
+  afterEach(() => {
+    resetTabStore();
+  });
+
+  it("strips focus fields from a timeline tab", () => {
+    const id = useTabStore.getState().openTab(
+      {
+        kind: "timeline",
+        sessionId: "session-a",
+        focusTurnId: 42,
+        focusPairId: "tool_xyz",
+        focusKey: "k1",
+      },
+      "bottom",
+    );
+
+    useTabStore.getState().clearTimelineFocus(id);
+
+    const tab = useTabStore.getState().tabs[id]!;
+    expect(tab.focusTurnId).toBeUndefined();
+    expect(tab.focusPairId).toBeUndefined();
+    expect(tab.focusKey).toBeUndefined();
+  });
+
+  it("is a no-op for tabs with no focus set", () => {
+    const id = useTabStore
+      .getState()
+      .openTab({ kind: "timeline", sessionId: "session-a" }, "bottom");
+    const before = useTabStore.getState().tabs[id];
+    useTabStore.getState().clearTimelineFocus(id);
+    expect(useTabStore.getState().tabs[id]).toBe(before);
+  });
+
+  it("is a no-op for non-timeline tabs", () => {
+    const id = useTabStore
+      .getState()
+      .openTab({ kind: "file", repo: "alpha", path: "src/lib.rs" }, "top");
+    const before = useTabStore.getState().tabs[id];
+    useTabStore.getState().clearTimelineFocus(id);
+    expect(useTabStore.getState().tabs[id]).toBe(before);
+  });
+});

--- a/frontend/src/state/TabStore.tsx
+++ b/frontend/src/state/TabStore.tsx
@@ -50,6 +50,11 @@ export interface TabStore {
   moveTab: (id: string, toPane: PaneId, index?: number) => void;
   rebindSessionTabs: (fromSessionId: string, toSessionId: string) => void;
   setPaneSticky: (pane: PaneId, value: boolean) => void;
+  /** Strip `focusTurnId` / `focusPairId` / `focusKey` from a timeline
+   * tab. Called when the user manually picks a turn, so subsequent
+   * polls (or tab revisits) don't snap the selection back to the old
+   * focus target. */
+  clearTimelineFocus: (id: string) => void;
 }
 
 interface PersistedTabs {
@@ -210,6 +215,27 @@ export const useTabStore = create<TabStore>()(
         set((state) => ({
           sticky: { ...state.sticky, [pane]: value },
         })),
+
+      clearTimelineFocus: (id) =>
+        set((state) => {
+          const tab = state.tabs[id];
+          if (
+            !tab
+            || tab.kind !== "timeline"
+            || (tab.focusTurnId == null
+              && tab.focusPairId == null
+              && tab.focusKey == null)
+          ) {
+            return state;
+          }
+          const stripped: TabData = { ...tab };
+          delete stripped.focusTurnId;
+          delete stripped.focusPairId;
+          delete stripped.focusKey;
+          return {
+            tabs: { ...state.tabs, [id]: stripped },
+          };
+        }),
 
       rebindSessionTabs: (fromSessionId, toSessionId) => {
         if (fromSessionId === toSessionId) return;


### PR DESCRIPTION
rustup installs under /usr/local/cargo root-owned, so cargo can't populate the registry cache when the dev user runs make ci inside a PTY. Relax the post-install chmod from a+rX to a+rwX on both /usr/local/rustup and /usr/local/cargo — same convention the official rust Docker image uses for shared toolchains.